### PR TITLE
【ポートフォリオ実装】20200417

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -55,7 +55,7 @@ export default {
 #footerScroll {
   border-radius: 50%;
   position: relative;
-  top: -55px;
+  top: -50px;
   width: 30px;
 }
 

--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -50,8 +50,8 @@ export default {
 
 #profilePicture {
   border-radius: 50%;
-  width: 90px;
-  height: 90px;
+  width: 120px;
+  height: 120px;
   display: block;
   margin: auto;
   padding: 0 0 10px 0;

--- a/src/components/Skill.vue
+++ b/src/components/Skill.vue
@@ -12,6 +12,7 @@
     </div>
     <div id="skillLink">
       GitHub：<a
+        id="gitHubLink"
         href="http://github.com/yuto0627"
         target="_blank"
       >https://github.com/yuto0627</a>
@@ -154,6 +155,12 @@ export default {
   font-size: 18px;
   text-align: center;
   padding: 15px 0 10px 0;
+}
+
+#gitHubLink {
+  color: #20879f;
+  font-size: 18px;
+  font-weight: bold;
 }
 
 li {


### PR DESCRIPTION
# レビュー観点
- ポートフォリオの周りの余白をなくそうと思い、reset.cssで修正したのですが、全体的にズレが生じてしまい修正に時間がかかってしまった為、完了させることが出来ませんでした。
- Footerの下の部分の余白の修正したかったのですが出来ていない状況です。

# 変更内容／作業内容
- プロフィール画像の大きさを少し大きくしました。
- GitHubのラベルの色を変更しました。

# Before
<img width="1440" alt="スクリーンショット 2020-04-16 18 26 41" src="https://user-images.githubusercontent.com/62985456/79543766-f0ccf580-80c8-11ea-869f-2a1e8b105d7f.png">
<img width="1429" alt="スクリーンショット 2020-04-16 18 26 57" src="https://user-images.githubusercontent.com/62985456/79543773-f296b900-80c8-11ea-9c65-c1709b5f6c1c.png">


# After
<img width="1440" alt="スクリーンショット 2020-04-17 16 30 55" src="https://user-images.githubusercontent.com/62985456/79543739-e7dc2400-80c8-11ea-9795-855283938ec5.png">
<img width="1440" alt="スクリーンショット 2020-04-17 16 31 04" src="https://user-images.githubusercontent.com/62985456/79543744-e9a5e780-80c8-11ea-9c1e-6874c605de50.png">

